### PR TITLE
scratch ipv6 base classes

### DIFF
--- a/gpuflow/dataplane/gpu/cuda/cuda_lpm_factory.cu
+++ b/gpuflow/dataplane/gpu/cuda/cuda_lpm_factory.cu
@@ -37,6 +37,7 @@ __global__ void InitIPv6LPMTable(IPv6RuleEntry *ipv6_tbl_24) {
   ipv6_tbl_24[idx].valid_flag = false;
   ipv6_tbl_24[idx].depth = 0;
   ipv6_tbl_24[idx].external_flag = false;
+  ipv6_tbl_24[idx].tbl8_ptr = nullptr;
 }
 
 // Create LPM Table

--- a/gpuflow/dataplane/gpu/cuda/cuda_lpm_factory.h
+++ b/gpuflow/dataplane/gpu/cuda/cuda_lpm_factory.h
@@ -61,10 +61,11 @@ class IPv6LPMFactory {
       MAX_LPM_ROUTING_RULES *= 2;
     }
   }
-  unsigned const int MAX_DEPTH = 24;
+  unsigned const int MAX_DEPTH = 128;
   unsigned long MAX_LPM_ROUTING_RULES;
   IPv6RuleEntry *IPv6TBL24;
   int CreateLPMTable();
+  int AddLPMRule(uint8_t *ipv6_address, uint8_t depth, uint8_t next_hop);
   ~IPv6LPMFactory() {
     cudaFree(IPv6TBL24);
   }

--- a/gpuflow/dataplane/gpu/cuda/cuda_lpm_factory.h
+++ b/gpuflow/dataplane/gpu/cuda/cuda_lpm_factory.h
@@ -20,6 +20,14 @@ struct IPv4RuleEntry {
   uint8_t depth;
 };
 
+struct IPv6RuleEntry {
+  uint8_t next_hop;
+  bool valid_flag;
+  // The external flag will be used when the depth exceed 24 bits.
+  bool external_flag;
+  uint8_t depth;
+  IPv6RuleEntry *tbl8_ptr;
+};
 namespace cu {
 
 class IPv4LPMFactory {
@@ -40,6 +48,24 @@ class IPv4LPMFactory {
   int AddLPMRule(uint32_t ipv4_address, uint8_t depth, uint8_t next_hop);
   ~IPv4LPMFactory() {
     cudaFree(IPv4TBL24);
+  }
+};
+
+class IPv6LPMFactory {
+ public:
+  IPv6LPMFactory() : IPv6TBL24(nullptr) {
+    // 2 ^ 24 rules
+    MAX_LPM_ROUTING_RULES = 1;
+    for (int i = 0; i < 24; i++) {
+      MAX_LPM_ROUTING_RULES *= 2;
+    }
+  }
+  unsigned const int MAX_DEPTH = 24;
+  unsigned long MAX_LPM_ROUTING_RULES;
+  IPv6RuleEntry *IPv6TBL24;
+  int CreateLPMTable();
+  ~IPv6LPMFactory() {
+    cudaFree(IPv6TBL24);
   }
 };
 

--- a/gpuflow/dataplane/gpu/cuda/cuda_lpm_factory.h
+++ b/gpuflow/dataplane/gpu/cuda/cuda_lpm_factory.h
@@ -28,6 +28,7 @@ struct IPv6RuleEntry {
   uint8_t depth;
   IPv6RuleEntry *tbl8_ptr;
 };
+
 namespace cu {
 
 class IPv4LPMFactory {

--- a/gpuflow/dataplane/gpu/dataplane_lpm_gpu.cpp
+++ b/gpuflow/dataplane/gpu/dataplane_lpm_gpu.cpp
@@ -35,5 +35,28 @@ int DataPlaneLPMIPv4GPU::CreateLPMTable() {
   return 0;
 }
 
+DataPlaneLPMIPv6GPU::DataPlaneLPMIPv6GPU() {
+  if(CreateLPMTable() < 0) {
+    std::cerr << "Error occured on creating ipv6 lpm table" << std::endl;
+    exit(1);
+  }  
+}
+
+int DataPlaneLPMIPv6GPU::CreateLPMTable() {
+  if(ipv6_lpm_factory.CreateLPMTable() < 0) {
+    std::cerr << "Create lpm table error from ipv6 lpm factory";  
+    exit(1);
+  } else {
+    std::cout << "Create lpm table from ipv6 lpm factory successfully." << std::endl;
+  }
+  if (ipv6_lpm_factory.IPv6TBL24 != nullptr) {
+    IPv6TBL24 = ipv6_lpm_factory.IPv6TBL24;
+    std::cout << "The IPv6TBL24 pointer is existed" << std::endl;
+  } else {
+    std::cerr << "The IPv6TBL24 pointer isn't existed" << std::endl;
+    exit(1);
+  }
+  return 0;
+}
 
 } // namespace gpuflow

--- a/gpuflow/dataplane/gpu/dataplane_lpm_gpu.h
+++ b/gpuflow/dataplane/gpu/dataplane_lpm_gpu.h
@@ -23,6 +23,18 @@ class DataPlaneLPMIPv4GPU {
   int CreateLPMTable();
 };
 
+class DataPlaneLPMIPv6GPU {
+ public:
+  DataPlaneLPMIPv6GPU();
+
+  //Delegate pointer on this class.
+  IPv6RuleEntry *IPv6TBL24;
+ 
+ private:
+  cu::IPv6LPMFactory ipv6_lpm_factory;
+  int CreateLPMTable();
+};
+
 } // namespace gpuflow
 
 #endif // _DATAPLANE_LPM_GPU_H_


### PR DESCRIPTION
1. Create a DataPlaneLPMIPv6GPU class in dataplane_lpm_gpu.h/.cpp
2. Create a IPv6LPMFactory class in cuda_lpm_factory.h/.cpp. However, the AddLPMRule function has not been implemented yet.