### PR TITLE
Add the tbl8 table settup in the factory class of ipv6

### DIFF
--- a/gpuflow/dataplane/gpu/cuda/cuda_lpm_factory.cu
+++ b/gpuflow/dataplane/gpu/cuda/cuda_lpm_factory.cu
@@ -40,6 +40,15 @@ __global__ void InitIPv6LPMTable(IPv6RuleEntry *ipv6_tbl_24) {
   ipv6_tbl_24[idx].tbl8_ptr = nullptr;
 }
 
+__global__ void InitIPv6TBL8Table(IPv6RuleEntry *ipv6_tbl_8) {
+  int idx = threadIdx.x;
+  ipv6_tbl_8[idx].next_hop = 254;
+  ipv6_tbl_8[idx].valid_flag = false;
+  ipv6_tbl_8[idx].depth = 0;
+  ipv6_tbl_8[idx].external_flag = false;
+  ipv6_tbl_8[idx].tbl8_ptr = nullptr;
+}
+
 // Create LPM Table
 int IPv4LPMFactory::CreateLPMTable() {
   // Allocate lpm table sizes
@@ -86,20 +95,28 @@ int IPv4LPMFactory::AddLPMRule(uint32_t ipv4_address, uint8_t depth, uint8_t nex
   return 0;
 }
 
-__global__ void SetupIPv6RuleEntry(IPv6RuleEntry *ipv6_tbl_24, unsigned long int start, uint8_t next_hop, uint8_t depth) {
+__global__ void SetupIPv6RuleEntry(IPv6RuleEntry *ipv6_tbl_24, unsigned long int start, uint8_t next_hop, uint8_t depth, IPv6RuleEntry *ipv6_tbl_8) {
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (ipv6_tbl_24[start + idx].valid_flag && (ipv6_tbl_24[start + idx].depth > depth)) {
     // There's an existed rule and longer, abort this update
   } else {
-    // Add the new rule
-    // TODO: Currently, we only handle with the case of depth <= 24. The case of depth > 24 using the tbl8 table has not been implemented.
+    // Add the new rule and TBL24 points to the tbl8 table.
     ipv6_tbl_24[start + idx].next_hop = next_hop;
     ipv6_tbl_24[start + idx].valid_flag = true;
-    ipv6_tbl_24[start + idx].external_flag = false;
     ipv6_tbl_24[start + idx].depth = depth;
-    ipv6_tbl_24[start + idx].tbl8_ptr = nullptr;
+    ipv6_tbl_24[start + idx].tbl8_ptr = ipv6_tbl_8;
+    if (ipv6_tbl_8 != nullptr) ipv6_tbl_24[start + idx].external_flag = true;
     printf("Setup ipv6 lpm rule entry! index: %lu, next_hop: %d\n", (start + idx), next_hop);
   }
+}
+
+__global__ void SetupIPv6TBL8RuleEntry(IPv6RuleEntry *ipv6_tbl_8, IPv6RuleEntry *next_tbl_8, unsigned long start, uint8_t next_hop, uint8_t depth) {
+  int idx = threadIdx.x;
+  ipv6_tbl_8[start + idx].next_hop = next_hop;
+  ipv6_tbl_8[start + idx].valid_flag = true;
+  ipv6_tbl_8[start + idx].depth = depth;
+  ipv6_tbl_8[start + idx].tbl8_ptr = next_tbl_8;
+  if (next_tbl_8 != nullptr) ipv6_tbl_8[start + idx].external_flag = true;
 }
 
 int IPv6LPMFactory::AddLPMRule(uint8_t *ipv6_address, uint8_t depth, uint8_t next_hop) {
@@ -110,10 +127,13 @@ int IPv6LPMFactory::AddLPMRule(uint8_t *ipv6_address, uint8_t depth, uint8_t nex
 
   // Calculate the distance
   unsigned long int distance = 1;
-  for (unsigned long int i = 0; i < (24 - depth); i++) {
-    distance *= 2;
+  if (depth <= 24) {
+    for (unsigned long int i = 0; i < (24 - depth); i++) {
+      distance *= 2;
+    }
   }
 
+  IPv6RuleEntry **ipv6_tbl_8_array = nullptr;
   unsigned long int start = 0;
   if (depth == 24) {
     // The depth is exactly 24
@@ -147,18 +167,49 @@ int IPv6LPMFactory::AddLPMRule(uint8_t *ipv6_address, uint8_t depth, uint8_t nex
     start = right_shift << (24 - depth);
       
   } else {
-    // TODO: Handling when depth is larger than 24
+    // Handling when depth is larger than 24
     start = ipv6_address[0] << 16 | ipv6_address[1] << 8 | ipv6_address[2];
+   
+    // Calculate the number of tbl8 table 
+    int tbl_8_number = depth % 8 ? ((depth - 24) / 8) + 1 : (depth - 24) / 8;
+    
+    // Calculate the distance of the last tbl8 table. 
+    int tbl_8_last_table_distance = 1;
+    for (int i = 0; i < (depth % 8); i++) {
+      tbl_8_last_table_distance *= 2;
+    }
+   
+    // Malloc memory in the cuda device,  initialize them and set up the rules. 
+    ipv6_tbl_8_array = new IPv6RuleEntry *[tbl_8_number];
+    for (int i = 0; i < tbl_8_number; i++) {
+      CudaMallocWithFailOver((void **)&ipv6_tbl_8_array[i], 256 * sizeof(IPv6RuleEntry), "IPv6TBL8");
+      printf("Malloc ipv6 tbl8 table %d\n", i);
+      InitIPv6TBL8Table<<<1, 256>>>(ipv6_tbl_8_array[i]);
+      printf("Initialize tbl8 %d\n", i);
+      if (i < (tbl_8_number - 1)) {
+        // Not the last tbl8 table
+        SetupIPv6TBL8RuleEntry<<<1, 1>>>(ipv6_tbl_8_array[i], ipv6_tbl_8_array[i + 1], ipv6_address[3 + i], next_hop, depth);
+      } else {
+        // The last tbl8 table
+        SetupIPv6TBL8RuleEntry<<<1, tbl_8_last_table_distance>>>(ipv6_tbl_8_array[i], nullptr, ipv6_address[3 + i], next_hop, depth);
+      }
+    }
 
   }
 
   unsigned long num_of_threads = 1024;
   if (distance <= num_of_threads) {
-    SetupIPv6RuleEntry<<<1, distance>>>(IPv6TBL24, start, next_hop, depth); 
+    if (ipv6_tbl_8_array == nullptr) {
+      // TBL24 does not have to point to the tbl8 table.
+      SetupIPv6RuleEntry<<<1, distance>>>(IPv6TBL24, start, next_hop, depth, nullptr);
+    } else {
+      // TBL24 has to point to the tbl8 table.
+      SetupIPv6RuleEntry<<<1, distance>>>(IPv6TBL24, start, next_hop, depth, ipv6_tbl_8_array[0]);
+    }
   } else {
     // FIXME: Not correct sizes
     // Assume that distance == 1025 ?
-    SetupIPv6RuleEntry<<<distance/num_of_threads, num_of_threads>>>(IPv6TBL24, start, next_hop, depth);
+    SetupIPv6RuleEntry<<<distance/num_of_threads, num_of_threads>>>(IPv6TBL24, start, next_hop, depth, nullptr);
   }
   cudaDeviceSynchronize();
   return 0;


### PR DESCRIPTION
1. Malloc memory for tbl8 table and initialize the tables.
2. Set up the rules in the tbl8 table.
3. Set up the rule in the tbl24 table and make tbl24 table point to the first
   tbl8 table.